### PR TITLE
Vector B-grid tests

### DIFF
--- a/gcm_filters/kernels.py
+++ b/gcm_filters/kernels.py
@@ -713,6 +713,8 @@ class BgridVectorLaplacian(BaseVectorLaplacian):
     TAREA: T-cell area
     """
 
+    is_dimensional = True
+
     DXU: ArrayType
     DYU: ArrayType
     HUS: ArrayType
@@ -743,7 +745,7 @@ class BgridVectorLaplacian(BaseVectorLaplacian):
         p5 = 0.5
 
         # Calculate coefficients for the stencil without metric terms
-        WORK1 = (self.HUS / self.HTE)
+        WORK1 = self.HUS / self.HTE
 
         DUS = (
             WORK1 * self.UAREA_R
@@ -752,7 +754,7 @@ class BgridVectorLaplacian(BaseVectorLaplacian):
             np.roll(WORK1, 1, axis=-1) * self.UAREA_R
         )  # North coefficient of 5-point stencil
 
-        WORK1 = (self.HUW / self.HTN)
+        WORK1 = self.HUW / self.HTN
 
         DUW = WORK1 * self.UAREA_R  # West coefficient of 5-point stencil
         DUE = (
@@ -766,29 +768,17 @@ class BgridVectorLaplacian(BaseVectorLaplacian):
         KYU = (np.roll(self.HUS, 1, axis=-1) - self.HUS) * self.UAREA_R
 
         WORK1 = (self.HTE - np.roll(self.HTE, -1, axis=-2)) * self.TAREA_R  # KXT
-        WORK2 = (
-            p5
-            * (WORK1 + np.roll(WORK1, 1, axis=-1))
-        )
+        WORK2 = p5 * (WORK1 + np.roll(WORK1, 1, axis=-1))
         DXKX = (np.roll(WORK2, 1, axis=-2) - WORK2) * self.DXUR
 
-        WORK2 = (
-            p5
-            * (WORK1 + np.roll(WORK1, 1, axis=-2))
-        )
+        WORK2 = p5 * (WORK1 + np.roll(WORK1, 1, axis=-2))
         DYKX = (np.roll(WORK2, 1, axis=-1) - WORK2) * self.DYUR
 
         WORK1 = (self.HTN - np.roll(self.HTN, -1, axis=-1)) * self.TAREA_R  # KYT
-        WORK2 = (
-            p5
-            * (WORK1 + np.roll(WORK1, 1, axis=-2))
-        )
+        WORK2 = p5 * (WORK1 + np.roll(WORK1, 1, axis=-2))
         DYKY = (np.roll(WORK2, 1, axis=-1) - WORK2) * self.DYUR
 
-        WORK2 = (
-            p5
-            * (WORK1 + np.roll(WORK1, 1, axis=-1))
-        )
+        WORK2 = p5 * (WORK1 + np.roll(WORK1, 1, axis=-1))
         DXKY = (np.roll(WORK2, axis=-2, shift=1) - WORK2) * self.DXUR
 
         DUM = -(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,8 +9,7 @@ flake8-print
 interrogate
 isort
 nbsphinx
-netcdf4
-pooch
+numcodecs==0.10.1
 pre-commit
 pylint
 pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,34 @@ _grid_kwargs = {
     GridType.TRIPOLAR_POP_WITH_LAND: ["wet_mask", "dxe", "dye", "dxn", "dyn", "tarea"],
 }
 
+_vector_grid_kwargs = {
+    GridType.VECTOR_C_GRID: [
+        "wet_mask_t",
+        "wet_mask_q",
+        "dxT",
+        "dyT",
+        "dxCu",
+        "dyCu",
+        "dxCv",
+        "dyCv",
+        "dxBu",
+        "dyBu",
+        "area_u",
+        "area_v",
+        "kappa_iso",
+        "kappa_aniso",
+    ],
+    GridType.VECTOR_B_GRID: [
+        "DXU",
+        "DYU",
+        "HUS",
+        "HUW",
+        "HTE",
+        "HTN",
+        "UAREA",
+        "TAREA",
+    ],
+}
 
 scalar_grids = [
     GridType.REGULAR,
@@ -45,7 +73,7 @@ tripolar_grids = [
     GridType.TRIPOLAR_REGULAR_WITH_LAND_AREA_WEIGHTED,
     GridType.TRIPOLAR_POP_WITH_LAND,
 ]
-vector_grids = [GridType.VECTOR_C_GRID]
+vector_grids = [GridType.VECTOR_C_GRID, GridType.VECTOR_B_GRID]
 
 
 def _make_random_data(shape: Tuple[int, int], seed: int) -> np.ndarray:
@@ -150,72 +178,90 @@ def grid_type_and_input_ds(request, scalar_grid_type_data_and_extra_kwargs):
 
 
 @pytest.fixture(scope="session")
+# compute latitudes and longitudes for a spherical C-grid geometry
 def spherical_geometry():
+
     ny, nx = (128, 256)
 
     # construct spherical coordinate system similar to MOM6 NeverWorld2 grid
     # define latitudes and longitudes
     lat_min = -70
     lat_max = 70
-    lat_u = np.linspace(
+
+    # compute latitude of u-points on C-grid
+    latCu = np.linspace(
         lat_min + 0.5 * (lat_max - lat_min) / ny,
         lat_max - 0.5 * (lat_max - lat_min) / ny,
         ny,
     )
-    lat_v = np.linspace(lat_min + (lat_max - lat_min) / ny, lat_max, ny)
+    # compute latitude of v-points on C-grid
+    latCv = np.linspace(lat_min + (lat_max - lat_min) / ny, lat_max, ny)
+
     lon_min = 0
     lon_max = 60
-    lon_u = np.linspace(lon_min + (lon_max - lon_min) / nx, lon_max, nx)
-    lon_v = np.linspace(
+
+    lonCu = np.linspace(lon_min + (lon_max - lon_min) / nx, lon_max, nx)
+    lonCv = np.linspace(
         lon_min + 0.5 * (lon_max - lon_min) / nx,
         lon_max - 0.5 * (lon_max - lon_min) / nx,
         nx,
     )
-    (geolon_u, geolat_u) = np.meshgrid(lon_u, lat_u)
-    (geolon_v, geolat_v) = np.meshgrid(lon_v, lat_v)
 
-    return geolon_u, geolat_u, geolon_v, geolat_v
+    (geolonCu, geolatCu) = np.meshgrid(lonCu, latCu)
+    (geolonCv, geolatCv) = np.meshgrid(lonCv, latCv)
+
+    return geolonCu, geolatCu, geolonCv, geolatCv
 
 
 @pytest.fixture(scope="session", params=vector_grids)
 def vector_grid_type_data_and_extra_kwargs(request, spherical_geometry):
     grid_type = request.param
-    geolon_u, geolat_u, geolon_v, geolat_v = spherical_geometry
-    ny, nx = geolon_u.shape
+    geolonCu, geolatCu, geolonCv, geolatCv = spherical_geometry
+    ny, nx = geolonCu.shape
 
     extra_kwargs = {}
 
-    # for now, we assume that the only implemented vector grid is VECTOR_C_GRID
-    # we can relax this if we implement other vector grids
-    assert grid_type == GridType.VECTOR_C_GRID
-
     R = 6378000
+
     # dx varies spatially
-    extra_kwargs["dxCu"] = R * np.cos(geolat_u / 360 * 2 * np.pi)
-    extra_kwargs["dxCv"] = R * np.cos(geolat_v / 360 * 2 * np.pi)
-    extra_kwargs["dxBu"] = extra_kwargs["dxCv"] + np.roll(
-        extra_kwargs["dxCv"], -1, axis=1
-    )
-    extra_kwargs["dxT"] = extra_kwargs["dxCu"] + np.roll(
-        extra_kwargs["dxCu"], 1, axis=1
-    )
-    # dy is set constant, equal to dx at the equator
-    dy = np.max(extra_kwargs["dxCu"]) * np.ones((ny, nx))
-    extra_kwargs["dyCu"] = dy
-    extra_kwargs["dyCv"] = dy
-    extra_kwargs["dyBu"] = dy
-    extra_kwargs["dyT"] = dy
+    for name in _vector_grid_kwargs[grid_type]:
+        if name in ["dxCu", "dxT", "HUS", "HTE"]:
+            extra_kwargs[name] = R * np.cos(geolatCu / 360 * 2 * np.pi)
+            # compute dy for later
+            # dy is set constant, equal to dx at the equator
+            dy = np.max(extra_kwargs[name]) * np.ones((ny, nx))
+        if name in ["dxCv", "dxBu", "DXU", "HUW", "HTN"]:
+            extra_kwargs[name] = R * np.cos(geolatCv / 360 * 2 * np.pi)
+
+    # dy
+    for name in _vector_grid_kwargs[grid_type]:
+        if name in ["dyCu", "dyCv", "dyBu", "dyT", "DYU"]:
+            extra_kwargs[name] = dy
+
     # compute grid cell areas
-    extra_kwargs["area_u"] = extra_kwargs["dxCu"] * extra_kwargs["dyCu"]
-    extra_kwargs["area_v"] = extra_kwargs["dxCv"] * extra_kwargs["dyCv"]
+    for name in _vector_grid_kwargs[grid_type]:
+        if name == "area_u":
+            extra_kwargs[name] = extra_kwargs["dxCu"] * extra_kwargs["dyCu"]
+        elif name == "area_v":
+            extra_kwargs[name] = extra_kwargs["dxCv"] * extra_kwargs["dyCv"]
+        elif name == "UAREA":
+            extra_kwargs[name] = extra_kwargs["DXU"] * extra_kwargs["DYU"]
+        elif name == "TAREA":
+            # on a spherical grid, HTE is the same as x-spacing centered at tracer point
+            # on a spherical grid, DYU is the same as y-spacing centered at tracer point
+            extra_kwargs[name] = extra_kwargs["HTE"] * extra_kwargs["DYU"]
+
     # set isotropic and anisotropic kappas
-    extra_kwargs["kappa_iso"] = np.ones((ny, nx))
-    extra_kwargs["kappa_aniso"] = np.ones((ny, nx))
+    for name in _vector_grid_kwargs[grid_type]:
+        if name in ["kappa_iso", "kappa_aniso"]:
+            extra_kwargs[name] = np.ones((ny, nx))
+
     # put a big island in the middle
     mask_data = np.ones((ny, nx))
     mask_data[: (ny // 2), : (nx // 2)] = 0
-    extra_kwargs["wet_mask_t"] = mask_data
-    extra_kwargs["wet_mask_q"] = mask_data
+    for name in _vector_grid_kwargs[grid_type]:
+        if name in ["wet_mask_t", "wet_mask_q"]:
+            extra_kwargs[name] = mask_data
 
     data_u = _make_random_data((ny, nx), 42)
     data_v = _make_random_data((ny, nx), 43)


### PR DESCRIPTION
This PR makes modifications to `conftest.py` to make sure that the existing tests in `test_filter.py` and `test_kernels.py` work for the B-grid Laplacian, including the solid body rotation one! @paigem: I only had to fix minor typos after our screen-share hack session to make it work! :tada:

If you'd like to can verify this by running
```
pytest test_kernels.py
pytest test_filter.py
```
However, the following will still fail 
```
pytest test_kernels_validation.py
pytest test_filter_validation.py
```
because we haven't generated the zarr test data for the B-grid Laplacian.

**After** this is merged, we can generate the zarr test data for the B-grid Laplacian by typing
```
GCM_FILTERS_OVERWRITE_TEST_DATA=1 pytest tests/test_kernels_validation.py
GCM_FILTERS_OVERWRITE_TEST_DATA=1 pytest tests/test_filter_validation.py
```
and then 
```
pytest test_kernels_validation.py
pytest test_filter_validation.py
```
should pass.